### PR TITLE
--n 增加victoria-logs日志查询和日志指标告警

### DIFF
--- a/install/helm/kubedoor/Chart.yaml
+++ b/install/helm/kubedoor/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/starsliao/KubeDoor
 maintainers:
   - name: StarsL.cn
-  - url: https://github.com/starsliao
+    url: https://github.com/starsliao
 
-version: 1.5
+version: "1.5"
 appVersion: "1.5"

--- a/install/helm/kubedoor/templates/01.monit/0.vl-single.yaml
+++ b/install/helm/kubedoor/templates/01.monit/0.vl-single.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.kubedoor.master.enable }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: victorialogs-pvc
+  namespace: kubedoor
+  labels:
+    app: victorialogs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.logs.victorialogs.storage }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: victorialogs
+  namespace: kubedoor
+  labels:
+    app: victorialogs
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # 设置升级策略为Recreate,会终止所有旧pod后再创建新pod
+  selector:
+    matchLabels:
+      app: victorialogs
+  template:
+    metadata:
+      labels:
+        app: victorialogs
+    spec:
+      containers:
+      - name: victorialogs
+        image: registry.cn-hangzhou.aliyuncs.com/rhub/victorialogs:v1.23.3-victorialogs-scratch
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9428
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          successThreshold: 2
+          timeoutSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: 9428
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 9428
+          name: http
+        env:
+        - name: TZ
+          value: "Asia/Shanghai"
+        args:
+        - --storageDataPath=/victoria-logs-data
+        - --httpListenAddr=:9428
+        - --retentionPeriod={{ .Values.logs.victorialogs.retention }}
+        - --loggerFormat=json
+        - --loggerOutput=stderr
+        volumeMounts:
+        - name: victoria-logs-data
+          mountPath: /victoria-logs-data
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+      volumes:
+      - name: victoria-logs-data
+        persistentVolumeClaim:
+          claimName: victorialogs-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: victorialogs
+  namespace: kubedoor
+  labels:
+    app: victorialogs
+spec:
+  selector:
+    app: victorialogs
+  ports:
+  - port: 9428
+    targetPort: 9428
+    protocol: TCP
+    name: http
+  type: NodePort
+{{- end }}

--- a/install/helm/kubedoor/templates/01.monit/1.vector.yaml
+++ b/install/helm/kubedoor/templates/01.monit/1.vector.yaml
@@ -1,0 +1,353 @@
+{{- if .Values.monit.vector.enable }}
+############################################
+# Vector K8S DaemonSet - Containerd CRI 官方最佳实践版本  
+# 基于官方文档：https://github.com/vectordotdev/vector
+############################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config
+  namespace: kubedoor
+data:
+  vector.yaml: |
+    # 数据目录
+    data_dir: "/var/lib/vector"
+    
+    # API
+    api:
+      enabled: true
+      address: "0.0.0.0:8686"
+    
+    # 使用官方推荐的kubernetes_logs源
+    sources:
+      java_k8s_logs:
+        type: "kubernetes_logs"
+        # 官方推荐：自动处理多行日志合并
+        auto_partial_merge: true
+        # 只收集Java应用，通过标签过滤
+        extra_label_selector: "{{ .Values.monit.vector.backend_labels_key }}={{ .Values.monit.vector.backend_labels_value }}"
+      ng_k8s_access:
+        type: "kubernetes_logs"
+        # 只收集Java应用，通过标签过滤
+        extra_label_selector: "{{ .Values.monit.vector.ingress_labels_key }}={{ .Values.monit.vector.ingress_labels_value }}"
+    
+    # 1、只过滤健康检查
+    transforms:
+      java_filter_logs:
+        type: filter
+        inputs:
+          - java_k8s_logs
+        condition: |
+          # 只排除明显的健康检查
+          !contains(string!(.message), "/actuator/health") && 
+          !contains(string!(.message), "/health")
+      # 2、Java多行日志增强处理
+      java_merge_multiline_logs:
+        type: reduce
+        inputs: [java_filter_logs]
+        group_by:
+          - pod_name
+          - container_name
+        merge_strategies:
+          message: concat_newline
+        starts_when:
+          type: vrl
+          source: |
+            match(string!(.message), r'{{ .Values.monit.vector.backend_log_match }}')
+        expire_after_ms: 5000
+        flush_period_ms: 1000
+      
+      # 3、添加VictoriaLogs所需的_msg字段
+      java_add_msg_field:
+        type: remap
+        inputs: [java_merge_multiline_logs]
+        source: |
+          # 保留message字段并重命名为_msg
+          ._msg = .message
+
+          # 用正则匹配日志级别
+          match, err = parse_regex(._msg, r'^(?P<ts>\S+\s+\S+)\s+(?P<level>[A-Z]+)\s+.*')
+          if err == null {
+            .level = match.level
+          } else {
+            .level = "unknown"
+          }
+
+          # 创建新对象只包含需要的字段
+          .log_type  = "java"
+          . = {
+            "_msg": ._msg,
+            "level": .level,
+            "log_type": .log_type,
+            "kubernetes": {
+              "pod_namespace": .kubernetes.pod_namespace,
+              "pod_name": .kubernetes.pod_name,
+              "container_name": .kubernetes.container_name,
+              "pod_node_name": .kubernetes.pod_node_name
+            }
+          }
+          .namespace = .kubernetes.pod_namespace
+          del(.kubernetes.pod_namespace)
+          .pod = .kubernetes.pod_name
+          del(.kubernetes.pod_name)
+          .service = .kubernetes.container_name
+          del(.kubernetes.container_name)
+          .node = .kubernetes.pod_node_name
+          del(.kubernetes.pod_node_name)
+
+      nginx_format_access:
+        drop_on_error: true
+        reroute_dropped: true
+        type: remap
+        inputs:
+          - ng_k8s_access
+        source: |
+          ._msg = .message
+          # 解析JSON到临时变量，避免覆盖整个事件
+          parsed_json = parse_json!(replace(.message, r'([^\x00-\x7F])', "\\\\$$1") ?? .message)
+          if exists(parsed_json.message) {
+            parsed_json = parse_json!(replace(parsed_json.message, "\\x", "\\\\x") ?? parsed_json.message)
+          }
+          # 将解析的字段合并到当前事件，保留_msg
+          . = merge!(., parsed_json)
+          .createdtime = to_unix_timestamp(now(), unit: "milliseconds")
+          .timestamp = to_unix_timestamp(parse_timestamp!(.timestamp , format: "%+"), unit: "milliseconds")
+          .url_list = split!(.url, "?", 2)
+          .path = .url_list[0]
+          .query = .url_list[1]
+          .path_list = split!(.path, "/", 3)
+          if length(.path_list) > 2 {.top_path = join!(["/", .path_list[1]])} else {.top_path = "/"}
+          .upstreamtime = to_float(.upstreamtime) ?? 0
+          .duration = round((to_float(.responsetime) ?? 0) - to_float(.upstreamtime),3)
+          if .xff == "-" { .xff = .remote_ip }
+          .client_ip = split!(.xff, ",", 2)[0]
+          .ua = parse_user_agent!(.http_user_agent , mode: "enriched")
+          .client_browser_family = .ua.browser.family
+          .client_browser_major = .ua.browser.major
+          .client_os_family = .ua.os.family
+          .client_os_major = .ua.os.major
+          .client_device_brand = .ua.device.brand
+          .client_device_model = .ua.device.model
+          
+          # GeoIP 查询必须传字符串表名
+          .geoip = get_enrichment_table_record("geoip_table", {"ip": .client_ip}) ?? {"city_name":"unknown","region_name":"unknown","country_name":"unknown"}
+          .client_city = .geoip.city_name
+          .client_region = .geoip.region_name
+          .client_country = .geoip.country_name
+          .client_latitude = .geoip.latitude
+          .client_longitude = .geoip.longitude
+          # 只保留nginx字段
+          .log_type  = "nginx"
+          . = {
+            "_msg": ._msg,
+            "log_type": .log_type,
+            "timestamp": .timestamp,
+            "createdtime": .createdtime,
+            "server_ip": .server_ip,
+            "remote_ip": .remote_ip,
+            "xff": .xff,
+            "remote_user": .remote_user,
+            "domain": .domain,
+            "url": .url,
+            "path": .path,
+            "query": .query,
+            "top_path": .top_path,
+            "referer": .referer,
+            "upstreamtime": .upstreamtime,
+            "responsetime": .responsetime,
+            "duration": .duration,
+            "request_method": .request_method,
+            "status": .status,
+            "response_length": .response_length,
+            "request_length": .request_length,
+            "protocol": .protocol,
+            "upstreamhost": .upstreamhost,
+            "http_user_agent": .http_user_agent,
+            "client_ip": .client_ip,
+            "client_browser_family": .client_browser_family,
+            "client_browser_major": .client_browser_major,
+            "client_os_family": .client_os_family,
+            "client_os_major": .client_os_major,
+            "client_device_brand": .client_device_brand,
+            "client_device_model": .client_device_model,
+            "client_city": .client_city,
+            "client_region": .client_region,
+            "client_country": .client_country,
+            "client_latitude": .client_latitude,
+            "client_longitude": .client_longitude
+          }
+    
+    # 输出
+    sinks:
+      # VictoriaLogs
+      victorialogs:
+        type: loki
+        inputs: 
+          - java_add_msg_field
+          - nginx_format_access
+        endpoint: "http://{{ .Values.logs.victorialogs.host }}:{{ .Values.logs.victorialogs.port }}"
+        path: /insert/loki/api/v1/push
+        labels:
+          {{ .Values.tsdb.external_labels_key }}: {{ .Values.tsdb.external_labels_value }}
+          env: {{ .Values.tsdb.external_labels_value }}
+        encoding:
+          codec: json
+        # 添加批处理和缓冲配置
+        batch:
+          max_bytes: 102400
+          timeout_secs: 5
+        buffer:
+          type: memory
+          max_events: 1000
+          when_full: drop_newest
+        # 禁用健康检查避免400错误
+        healthcheck: false
+        request:
+          timeout_secs: 30
+      dropped_console:
+        type: console
+        inputs: ["nginx_format_access.dropped"]
+        encoding:
+          codec: json
+    enrichment_tables:
+      geoip_table:
+        path: "/usr/share/GeoIP/GeoLite2-City.mmdb"
+        type: geoip
+        locale: "zh-CN" #获取到的地域信息使用中文显示，删掉这行默认是英文显示，能解析数据量会比中文多一点点
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector
+  namespace: kubedoor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes  
+      - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vector
+subjects:
+  - kind: ServiceAccount
+    name: vector
+    namespace: kubedoor
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vector
+  namespace: kubedoor
+  labels:
+    app: vector
+spec:
+  selector:
+    matchLabels:
+      app: vector
+  template:
+    metadata:
+      labels:
+        app: vector
+    spec:
+      serviceAccountName: vector
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: vector
+        image: registry.cn-hangzhou.aliyuncs.com/rhub/timberio.vector:0.49.X
+        imagePullPolicy: Always
+        env:
+        - name: VECTOR_SELF_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: VECTOR_LOG
+          value: "warn"
+        - name: TZ
+          value: "Asia/Shanghai"
+        - name: PROCFS_ROOT
+          value: "/host/proc"
+        - name: SYSFS_ROOT
+          value: "/host/sys"
+        ports:
+        - name: api
+          containerPort: 8686
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/vector
+        - name: data
+          mountPath: /var/lib/vector
+        - name: var-log
+          mountPath: /var/log
+          readOnly: true
+        - name: run-containerd
+          mountPath: /run/containerd/containerd.sock
+          readOnly: true
+        - name: var-lib-containerd
+          mountPath: /var/lib/containerd
+          readOnly: true
+        - name: proc
+          mountPath: /host/proc
+          readOnly: true
+        - name: sys
+          mountPath: /host/sys
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: api
+          initialDelaySeconds: 30
+          periodSeconds: 30
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - "until nc -z {{ .Values.logs.victorialogs.host }} {{ .Values.logs.victorialogs.port }}; do echo waiting for basic service `date`; sleep 3; done;"
+        image: registry.cn-hangzhou.aliyuncs.com/rhub/busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: wait-basic
+      volumes:
+      - name: config
+        configMap:
+          name: vector-config
+      - name: data
+        hostPath:
+          path: /var/lib/vector
+          type: DirectoryOrCreate
+      - name: var-log
+        hostPath:
+          path: /var/log
+      - name: run-containerd
+        hostPath:
+          path: /run/containerd/containerd.sock
+          type: Socket
+      - name: var-lib-containerd
+        hostPath:
+          path: /var/lib/containerd
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: sys
+        hostPath:
+          path: /sys
+{{- end }}

--- a/install/helm/kubedoor/templates/01.monit/2.vmalert-logs.yaml
+++ b/install/helm/kubedoor/templates/01.monit/2.vmalert-logs.yaml
@@ -1,0 +1,151 @@
+{{- if .Values.kubedoor.master.enable }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vmalert-logs-config
+  namespace: kubedoor
+data:
+  logs.yaml: |-
+    groups:
+    - name: VictoriaLogs_Java_Alerts
+      type: vlogs
+      labels:
+        {{ .Values.tsdb.external_labels_key }}: {{ .Values.tsdb.external_labels_value }}
+      rules:
+      - alert: Java应用ERROR日志过多
+        expr: |
+          _time:5m AND log_type: "java" AND level: "ERROR" | stats by (service) count() as error_count | filter error_count :> 100
+        for: 3m
+        labels:
+          severity: Warning
+        annotations:
+          description: "K8S：{{`{{ $labels.`}}{{ .Values.tsdb.external_labels_key }}{{` }}`}}\n- 服务：{{`{{ $labels.service }}`}}\n- ERROR日志频率：{{`{{ $value | printf \"%.2f\" }}`}}/秒"
+
+      - alert: Java应用异常堆栈日志
+        expr: |
+          _time:5m AND log_type: "java" AND (level: "ERROR" OR level: "WARN") |~ "Exception|ERROR|Throwable" | stats by (service) count() as exception_count | filter exception_count :> 150
+        for: 2m
+        labels:
+          severity: Critical
+        annotations:
+          description: "K8S：{{`{{ $labels.`}}{{ .Values.tsdb.external_labels_key }}{{` }}`}}\n- 服务：{{`{{ $labels.service }}`}}\n- 异常堆栈频率：{{`{{ $value | printf \"%.2f\" }}`}}/秒"
+
+      - alert: Java应用OutOfMemoryError
+        expr: |
+          _time:5m AND log_type: "java" |~ "OutOfMemoryError" | stats by (service) count() as oom_count | filter oom_count :> 0
+        for: 1m
+        labels:
+          severity: Critical
+        annotations:
+          description: "K8S：{{`{{ $labels.`}}{{ .Values.tsdb.external_labels_key }}{{` }}`}}\n- 服务：{{`{{ $labels.service }}`}}\n- 检测到OutOfMemoryError"
+
+      - alert: Java应用数据库连接异常
+        expr: |
+          _time:5m AND log_type: "java" |~ "Connection.*timeout|Connection.*refused|Connection.*reset" | stats by (service) count() as conn_error_count | filter conn_error_count :> 2
+        for: 3m
+        labels:
+          severity: Warning
+        annotations:
+          description: "K8S：{{`{{ $labels.`}}{{ .Values.tsdb.external_labels_key }}{{` }}`}}\n- 服务：{{`{{ $labels.service }}`}}\n- 数据库连接异常频率：{{`{{ $value | printf \"%.2f\" }}`}}/秒"
+
+    - name: VictoriaLogs_Nginx_Alerts
+      type: vlogs
+      labels:
+        {{ .Values.tsdb.external_labels_key }}: {{ .Values.tsdb.external_labels_value }}
+      rules:
+      - alert: Nginx_5xx错误率过高
+        expr: |
+          _time:5m AND log_type: "nginx" | extract "domain=<domain> " | extract "status=<status>;" | stats by (domain) count() if (status:~5.*) as failed, count() as total| math failed / total as failed_percentage| filter failed_percentage :> 0.01 | fields domain,failed_percentage
+        for: 3m
+        labels:
+          severity: Critical
+        annotations:
+          description: "K8S：{{`{{ $labels.`}}{{ .Values.tsdb.external_labels_key }}{{` }}`}}\n- 域名：{{`{{ $labels.domain }}`}}\n- 5xx错误率：{{`{{ $value | printf \"%.2f\" }}`}}%"
+
+      - alert: Nginx_4xx错误率过高
+        expr: |
+          _time:5m AND log_type: "nginx" | extract "domain=<domain> " | extract "status=<status>;" | stats by (domain) count() if (status:~4.*) as failed, count() as total| math failed / total as failed_percentage| filter failed_percentage :> 0.01 | fields domain,failed_percentage
+        for: 3m
+        labels:
+          severity: Warning
+        annotations:
+          description: "K8S：{{`{{ $labels.`}}{{ .Values.tsdb.external_labels_key }}{{` }}`}}\n- 域名：{{`{{ $labels.domain }}`}}\n- 4xx错误率：{{`{{ $value | printf \"%.2f\" }}`}}%"
+
+      - alert: Nginx响应时间过长
+        expr: |
+          _time:5m AND log_type: "nginx" | extract "domain=<domain> " | extract "responsetime=<responsetime>" | stats by (domain) quantile(0.95, responsetime) as p95_response_time | filter p95_response_time :> 2
+        for: 5m
+        labels:
+          severity: Warning
+        annotations:
+          description: "K8S：{{`{{ $labels.`}}{{ .Values.tsdb.external_labels_key }}{{` }}`}}\n- 域名：{{`{{ $labels.domain }}`}}\n- 95%响应时间：{{`{{ $value | printf \"%.2f\" }}`}}秒"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vmalert-logs
+  namespace: kubedoor
+  labels:
+    app: vmalert-logs
+spec:
+  ports:
+    - name: vmalert
+      port: 8080
+      targetPort: 8080
+  type: NodePort
+  selector:
+    app: vmalert-logs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vmalert-logs
+  namespace: kubedoor
+  labels:
+    app: vmalert-logs
+spec:
+  selector:
+    matchLabels:
+      app: vmalert-logs
+  template:
+    metadata:
+      labels:
+        app: vmalert-logs
+    spec:
+      containers:
+        - name: vmalert
+          image: registry.cn-shenzhen.aliyuncs.com/starsl/vmalert:stable
+          imagePullPolicy: IfNotPresent
+          args:
+            # VictoriaLogs数据源配置
+            - -datasource.url=http://{{ .Values.logs.victorialogs.host }}:{{ .Values.logs.victorialogs.port }}
+            - -notifier.url=http://alertmanager.kubedoor:9093
+            - -remoteWrite.url=http://{{ .Values.tsdb.vm_single.user }}:{{ .Values.tsdb.vm_single.passwd }}@victoria-metrics.kubedoor:8428
+            - -remoteRead.url=http://{{ .Values.tsdb.vm_single.user }}:{{ .Values.tsdb.vm_single.passwd }}@victoria-metrics.kubedoor:8428
+            - -rule=/etc/ruler/*.yaml
+            - -evaluationInterval=15s
+            - -rule.defaultRuleType=vlogs
+            - -httpListenAddr=0.0.0.0:8080
+          env:
+            - name: TZ
+              value: Asia/Shanghai
+          resources:
+            limits:
+              cpu: '1'
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - mountPath: /etc/ruler/
+              name: ruler
+              readOnly: true
+      volumes:
+        - configMap:
+            name: vmalert-logs-config
+          name: ruler
+{{- end }}

--- a/install/helm/kubedoor/values-agent.yaml
+++ b/install/helm/kubedoor/values-agent.yaml
@@ -19,12 +19,6 @@ config:
 tsdb:
   # 以下两个字段用于多K8S监控数据，通过远程写方式，写入到同一个时序数据库的场景，即为Prometheus/vmagent设置中的external_labels的key/value。
   # 使用远程存储时，这个key/value会作为标签增加到每一个指标中，这样通过这个标签就可以区分出指标属于哪个K8S了。
-
-  external_labels_key: "origin_prometheus" # 注意key只能字母数字下划线。注意所有external_labels_key的值都相同。
-  # 请填写您的K8S名称。如果是使用您已有的Prometheus，请在您的Prometheus配置中找到external_labels的value填入。
-  external_labels_value: "my-test-k8s"
-
-
   #【注意】如果您当前K8S已经有完整的Prometheus/vmagent监控，并且是远程写入时序数据库，则以下remoteWriteUrl不用管，并且请把以下所有的enable都设置为false，将不会安装false的组件。
 
   # 当您需要kubedoor-agent为您安装vmagent时才需要配置这个地址。
@@ -45,3 +39,12 @@ monit:
   # 用于Prometheus采集K8S节点数据指标，如果K8S节点已部署node-exporter可设置为false
   node_exporter:
     enable: true
+  # vector采集java和ingress的日志。
+  vector:
+    enable: true
+    backend_labels_key: "app/component"
+    backend_labels_value: "java"
+    # 日志匹配格式，默认匹配java日志格式，日志格式：2023-08-24 15:20:30.123。
+    backend_log_match: "^\\d{4}-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}:\\d{2}[.,]\\d{3}"
+    ingress_labels_key: "app.kubernetes.io/instance"
+    ingress_labels_value: "ingress-nginx"

--- a/install/helm/kubedoor/values-master.yaml
+++ b/install/helm/kubedoor/values-master.yaml
@@ -33,10 +33,6 @@ tsdb:
    
   # 如果是使用您已有的Victoria-Metrics，请在您的Prometheus/vmagent配置中找到external_labels的key填入，如果您没有配置过请在您的Prometheus配置中新增一个。
 
-  external_labels_key: "origin_prometheus" # 注意key只能字母数字下划线。
-
-  # external_labels_value: "" # master端不需要填写该字段。
-
   
 # 以下信息3选1填写:
 

--- a/install/helm/kubedoor/values.yaml
+++ b/install/helm/kubedoor/values.yaml
@@ -12,7 +12,18 @@ image:
   grafana_oss: 11.4.0
 
 tsdb:
-  type: "KubeDoor" 
+  type: "KubeDoor" # 时序数据库类型，可选：Victoria-Metrics-Single, Victoria-Metrics-Cluster, ClickHouse
+  external_labels_key: "origin_prometheus" # 注意key只能字母数字下划线。注意所有external_labels_key的值都相同。
+  # 请填写您的K8S名称。如果是使用您已有的Prometheus，请在您的Prometheus配置中找到external_labels的value填入。
+  external_labels_value: "dev-k8s"
+
+logs:
+  victorialogs:
+    host: "victorialogs.kubedoor"
+    port: "9428"
+    retention: 5d # 日志数据的存储时长
+    storage: 10Gi # 存储空间大小
+
 
 clickhouse:
   enable: false
@@ -29,4 +40,6 @@ monit:
   kube_state_metrics:
     enable: false
   node_exporter:
+    enable: false
+  vector:
     enable: false


### PR DESCRIPTION
<img width="1997" height="790" alt="未命名绘图 drawio" src="https://github.com/user-attachments/assets/acbd8273-bd85-49ac-a683-7d30b570528a" />

# 日志查询
vector推送pod的stdoutr日志到VictoriaLogs。标签在monit.vector定义

# 日志告警
新增一个vmalter，用于查询VictoriaLogs，然后按照`vmalert-logs-config`定义的告警规则发送告警给kubedoor的alertmanager。